### PR TITLE
[Refactor] #209 매장 오픈 알림 신청자 수를 사용자 기준으로 집계

### DIFF
--- a/src/main/java/com/magambell/server/notification/domain/repository/FcmTokenRepositoryImpl.java
+++ b/src/main/java/com/magambell/server/notification/domain/repository/FcmTokenRepositoryImpl.java
@@ -39,7 +39,7 @@ public class FcmTokenRepositoryImpl implements FcmTokenRepositoryCustom {
     @Override
     public long countByStoreId(final Long storeId) {
         Long count = queryFactory
-                .select(fcmToken.id.count())
+                .select(fcmToken.user.id.countDistinct())
                 .from(fcmToken)
                 .where(fcmToken.store.id.eq(storeId))
                 .fetchOne();

--- a/src/test/java/com/magambell/server/notification/app/service/NotificationServiceTest.java
+++ b/src/test/java/com/magambell/server/notification/app/service/NotificationServiceTest.java
@@ -179,7 +179,22 @@ class NotificationServiceTest {
         assertThat(subscriberCount).isEqualTo(2L);
     }
 
-    @DisplayName("매장 오픈 알림 신청자 수는 ACTIVE 여부와 관계없이 token row 기준으로 집계한다.")
+    @DisplayName("매장 오픈 알림 신청자 수는 중복 token row가 있어도 user 기준으로 집계한다.")
+    @Test
+    void getStoreOpenSubscriberCountDistinctUsers() {
+        // given
+        notificationService.saveStoreOpenToken(
+                new SaveStoreOpenFcmTokenServiceRequest(store.getId(), "token-1", user.getId()));
+        fcmTokenRepository.save(FcmToken.create("token-duplicate", user, store));
+
+        // when
+        long subscriberCount = notificationService.getStoreOpenSubscriberCount(store.getId());
+
+        // then
+        assertThat(subscriberCount).isEqualTo(1L);
+    }
+
+    @DisplayName("매장 오픈 알림 신청자 수는 ACTIVE 여부와 관계없이 user 기준으로 집계한다.")
     @Test
     void getStoreOpenSubscriberCountIncludesWithdrawnUser() {
         // given


### PR DESCRIPTION
## 🔗 Related Issue
 <!-- 연관된 이슈를 태그해 주세요. --> 
- close #209 

## 🪄 Work Description
 <!-- 작업한 내용을 간략히 설명해 주세요. -->
- 매장 오픈 알림 신청자 수 조회 로직을 기존 FCM 토큰 row 기준에서 사용자 수 기준으로 변경했습니다.
- 기존에는 `fcm_token_id`를 count하여 동일 사용자의 중복 구독 row가 존재할 경우 실제 인원 수보다 크게 집계될 수 있었습니다. 
- 이제 `user_id`를 distinct count하여 `~명이 가게 오픈을 기다려요` 문구에 맞게 고유 사용자 수를 반환합니다. 
- 개발/운영 DB의 `fcm_token` 테이블에 `idx_fcm_token_store_user(store_id, user_id)` 복합 인덱스가 존재하는 것을 확인했습니다.
```SQL
# 개발, 운영 서버 index 조회
SHOW INDEX FROM fcm_token;
```

Table | Non_unique | Key_name | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment | Ignored
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
fcm_token | 0 | PRIMARY | 1 | fcm_token_id | A | 328 | NULL | NULL |   | BTREE |   |   | NO
fcm_token | 1 | fcm_token_users_user_id_fk | 1 | user_id | A | 328 | NULL | NULL |   | BTREE |   |   | NO
fcm_token | 1 | idx_fcm_token_store_user | 1 | store_id | A | 17 | NULL | NULL | YES | BTREE |   |   | NO
fcm_token | 1 | idx_fcm_token_store_user | 2 | user_id | A | 328 | NULL | NULL |   | BTREE |   |   | NO

## 💥 Changes
<!-- 변경된 사항을 체크리스트로 작성해 주세요. -->
 - [x] `countByStoreId` 쿼리를 `fcmToken.id.count()`에서 `fcmToken.user.id.countDistinct()`로 변경
 - [x] 동일 사용자 중복 token row가 있어도 1명으로 집계되는 테스트 추가
 - [x] 기존 신청자 수 테스트 설명을 사용자 기준 집계 의도에 맞게 수정
 - [x] `fcm_token.store_id` 조회에 사용 가능한 복합 인덱스 존재 확인 
