### PR TITLE
[Feat] #211 리뷰 답글 도메인 및 API

### DIFF
--- a/src/main/java/com/magambell/server/common/enums/ErrorCode.java
+++ b/src/main/java/com/magambell/server/common/enums/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     INVALID_STORE_OWNER("잘못된 접근입니다."),
     INVALID_PAYMENT_STATUS("사용하지 않는 값 입니다."),
     INVALID_REVIEW_RATING("아쉬워요, 적당해요, 좋아요, 최고예요 중 선택해 주세요."),
+    INVALID_REVIEW_REPLY_CONTENT("답글은 1자 이상 500자 이하로 작성해 주세요."),
     INVALID_REJECT_REASON("선택할 수 없는 주문 거절 사유입니다."),
 
     INVALID_PORT_ONE_ACCESS_TOKEN("토큰 발급 실패"),

--- a/src/main/java/com/magambell/server/common/enums/ErrorCode.java
+++ b/src/main/java/com/magambell/server/common/enums/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     DUPLICATE_NICKNAME("중복된 닉네임 입니다."),
     DUPLICATE_GOODS("이미 등록된 바이트백입니다."),
     DUPLICATE_REVIEW("이미 등록된 리뷰입니다."),
+    DUPLICATE_REVIEW_REPLY("이미 등록된 리뷰 답글입니다."),
     DUPLICATE_FAVORITE("이미 즐겨찾기한 매장입니다."),
     DUPLICATE_NOTIFICATION_STORE("이미 알림 받기로한 매장입니다."),
     DUPLICATE_OPEN_REGION_REQUEST("이미 오픈 요청된 지역입니다."),

--- a/src/main/java/com/magambell/server/review/adapter/ReviewController.java
+++ b/src/main/java/com/magambell/server/review/adapter/ReviewController.java
@@ -9,6 +9,7 @@ import com.magambell.server.review.adapter.out.persistence.ReviewRatingSummaryRe
 import com.magambell.server.review.adapter.out.persistence.ReviewRegisterResponse;
 import com.magambell.server.review.adapter.out.persistence.ReviewReportListResponse;
 import com.magambell.server.review.app.port.in.ReviewUseCase;
+import com.magambell.server.review.app.port.in.request.DeleteReviewReplyServiceRequest;
 import com.magambell.server.review.app.port.in.request.DeleteReviewServiceRequest;
 import com.magambell.server.review.app.port.in.request.ReportReviewServiceRequest;
 import com.magambell.server.review.app.port.out.response.ReviewListDTO;
@@ -104,6 +105,35 @@ public class ReviewController {
             @AuthenticationPrincipal final CustomUserDetails customUserDetails
     ) {
         reviewUseCase.deleteReview(new DeleteReviewServiceRequest(reviewId, customUserDetails.userId()));
+
+        return new Response<>();
+    }
+
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "리뷰 답글 등록")
+    @ApiResponse(responseCode = "200", content = {
+            @Content(schema = @Schema(implementation = BaseResponse.class))})
+    @PostMapping("/{reviewId}/reply")
+    public Response<BaseResponse> registerReviewReply(
+            @PathVariable Long reviewId,
+            @RequestBody @Validated final RegisterReviewReplyRequest request,
+            @AuthenticationPrincipal final CustomUserDetails customUserDetails
+    ) {
+        reviewUseCase.registerReviewReply(request.toServiceRequest(reviewId, customUserDetails.userId()));
+
+        return new Response<>();
+    }
+
+    @PreAuthorize("hasRole('OWNER')")
+    @Operation(summary = "리뷰 답글 삭제")
+    @ApiResponse(responseCode = "200", content = {
+            @Content(schema = @Schema(implementation = BaseResponse.class))})
+    @DeleteMapping("/{reviewId}/reply")
+    public Response<BaseResponse> deleteReviewReply(
+            @PathVariable Long reviewId,
+            @AuthenticationPrincipal final CustomUserDetails customUserDetails
+    ) {
+        reviewUseCase.deleteReviewReply(new DeleteReviewReplyServiceRequest(reviewId, customUserDetails.userId()));
 
         return new Response<>();
     }

--- a/src/main/java/com/magambell/server/review/adapter/in/web/RegisterReviewReplyRequest.java
+++ b/src/main/java/com/magambell/server/review/adapter/in/web/RegisterReviewReplyRequest.java
@@ -1,0 +1,16 @@
+package com.magambell.server.review.adapter.in.web;
+
+import com.magambell.server.review.app.port.in.request.RegisterReviewReplyServiceRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterReviewReplyRequest(
+        @NotBlank(message = "답글을 작성해 주세요.")
+        @Size(max = 500, message = "답글은 최대 500자까지 작성할 수 있습니다.")
+        String content
+) {
+
+    public RegisterReviewReplyServiceRequest toServiceRequest(final Long reviewId, final Long userId) {
+        return new RegisterReviewReplyServiceRequest(reviewId, userId, content);
+    }
+}

--- a/src/main/java/com/magambell/server/review/adapter/out/persistence/ReviewCommandAdapter.java
+++ b/src/main/java/com/magambell/server/review/adapter/out/persistence/ReviewCommandAdapter.java
@@ -13,7 +13,9 @@ import com.magambell.server.review.app.port.out.response.ReviewPreSignedUrlImage
 import com.magambell.server.review.app.port.out.response.ReviewRegisterResponseDTO;
 import com.magambell.server.review.domain.entity.Review;
 import com.magambell.server.review.domain.entity.ReviewImage;
+import com.magambell.server.review.domain.entity.ReviewReply;
 import com.magambell.server.review.domain.entity.ReviewReport;
+import com.magambell.server.review.domain.repository.ReviewReplyRepository;
 import com.magambell.server.review.domain.repository.ReviewReportRepository;
 import com.magambell.server.review.domain.repository.ReviewRepository;
 import com.magambell.server.user.domain.entity.User;
@@ -27,6 +29,7 @@ public class ReviewCommandAdapter implements ReviewCommandPort {
     private static final String IMAGE_PREFIX = "REVIEW";
 
     private final ReviewRepository reviewRepository;
+    private final ReviewReplyRepository reviewReplyRepository;
     private final ReviewReportRepository reviewReportRepository;
     private final S3InputPort s3InputPort;
 
@@ -42,6 +45,11 @@ public class ReviewCommandAdapter implements ReviewCommandPort {
         reviewRepository.save(review);
 
         return new ReviewRegisterResponseDTO(review.getId(), reviewPreSignedUrlImages);
+    }
+
+    @Override
+    public void saveReviewReply(final ReviewReply reviewReply) {
+        reviewReplyRepository.save(reviewReply);
     }
 
     @Override

--- a/src/main/java/com/magambell/server/review/adapter/out/persistence/ReviewCommandAdapter.java
+++ b/src/main/java/com/magambell/server/review/adapter/out/persistence/ReviewCommandAdapter.java
@@ -2,6 +2,7 @@ package com.magambell.server.review.adapter.out.persistence;
 
 import com.magambell.server.common.annotation.Adapter;
 import com.magambell.server.common.enums.ErrorCode;
+import com.magambell.server.common.exception.DuplicateException;
 import com.magambell.server.common.exception.InvalidRequestException;
 import com.magambell.server.common.s3.S3InputPort;
 import com.magambell.server.common.s3.dto.ImageRegister;
@@ -21,12 +22,14 @@ import com.magambell.server.review.domain.repository.ReviewRepository;
 import com.magambell.server.user.domain.entity.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @RequiredArgsConstructor
 @Adapter
 public class ReviewCommandAdapter implements ReviewCommandPort {
 
     private static final String IMAGE_PREFIX = "REVIEW";
+    private static final String REVIEW_REPLY_REVIEW_ID_UNIQUE_CONSTRAINT = "uk_review_reply_review_id";
 
     private final ReviewRepository reviewRepository;
     private final ReviewReplyRepository reviewReplyRepository;
@@ -49,7 +52,14 @@ public class ReviewCommandAdapter implements ReviewCommandPort {
 
     @Override
     public void saveReviewReply(final ReviewReply reviewReply) {
-        reviewReplyRepository.save(reviewReply);
+        try {
+            reviewReplyRepository.saveAndFlush(reviewReply);
+        } catch (DataIntegrityViolationException e) {
+            if (isReviewReplyReviewIdUniqueConstraintViolation(e)) {
+                throw new DuplicateException(ErrorCode.DUPLICATE_REVIEW_REPLY);
+            }
+            throw e;
+        }
     }
 
     @Override
@@ -78,5 +88,22 @@ public class ReviewCommandAdapter implements ReviewCommandPort {
                     return new ReviewPreSignedUrlImage(imageDTO.id(), imageDTO.putUrl());
                 })
                 .toList();
+    }
+
+    private boolean isReviewReplyReviewIdUniqueConstraintViolation(final Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null && isReviewReplyReviewIdUniqueConstraintMessage(message.toLowerCase())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private boolean isReviewReplyReviewIdUniqueConstraintMessage(final String message) {
+        return message.contains(REVIEW_REPLY_REVIEW_ID_UNIQUE_CONSTRAINT)
+                || message.contains("review_reply(review_id");
     }
 }

--- a/src/main/java/com/magambell/server/review/app/port/in/ReviewUseCase.java
+++ b/src/main/java/com/magambell/server/review/app/port/in/ReviewUseCase.java
@@ -19,6 +19,10 @@ public interface ReviewUseCase {
 
     void deleteReview(DeleteReviewServiceRequest request);
 
+    void registerReviewReply(RegisterReviewReplyServiceRequest request);
+
+    void deleteReviewReply(DeleteReviewReplyServiceRequest request);
+
     void reportReview(ReportReviewServiceRequest request);
 
     List<ReviewReportListDTO> getReviewReportList(ReviewReportListServiceRequest request);

--- a/src/main/java/com/magambell/server/review/app/port/in/request/DeleteReviewReplyServiceRequest.java
+++ b/src/main/java/com/magambell/server/review/app/port/in/request/DeleteReviewReplyServiceRequest.java
@@ -1,0 +1,7 @@
+package com.magambell.server.review.app.port.in.request;
+
+public record DeleteReviewReplyServiceRequest(
+        Long reviewId,
+        Long userId
+) {
+}

--- a/src/main/java/com/magambell/server/review/app/port/in/request/RegisterReviewReplyServiceRequest.java
+++ b/src/main/java/com/magambell/server/review/app/port/in/request/RegisterReviewReplyServiceRequest.java
@@ -1,0 +1,8 @@
+package com.magambell.server.review.app.port.in.request;
+
+public record RegisterReviewReplyServiceRequest(
+        Long reviewId,
+        Long userId,
+        String content
+) {
+}

--- a/src/main/java/com/magambell/server/review/app/port/out/ReviewCommandPort.java
+++ b/src/main/java/com/magambell/server/review/app/port/out/ReviewCommandPort.java
@@ -3,10 +3,13 @@ package com.magambell.server.review.app.port.out;
 import com.magambell.server.review.app.port.in.dto.RegisterReviewDTO;
 import com.magambell.server.review.app.port.in.dto.ReportReviewDTO;
 import com.magambell.server.review.app.port.out.response.ReviewRegisterResponseDTO;
+import com.magambell.server.review.domain.entity.ReviewReply;
 import com.magambell.server.review.domain.entity.ReviewReport;
 
 public interface ReviewCommandPort {
     ReviewRegisterResponseDTO registerReview(RegisterReviewDTO dto);
+
+    void saveReviewReply(ReviewReply reviewReply);
 
     void reportReview(ReportReviewDTO dto);
 }

--- a/src/main/java/com/magambell/server/review/app/service/ReviewService.java
+++ b/src/main/java/com/magambell/server/review/app/service/ReviewService.java
@@ -18,6 +18,7 @@ import com.magambell.server.review.app.port.out.response.ReviewReportListDTO;
 import com.magambell.server.review.domain.entity.Review;
 import com.magambell.server.user.app.port.out.UserQueryPort;
 import com.magambell.server.user.domain.entity.User;
+import com.magambell.server.user.domain.enums.UserRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -73,6 +74,28 @@ public class ReviewService implements ReviewUseCase {
 
     @Transactional
     @Override
+    public void registerReviewReply(final RegisterReviewReplyServiceRequest request) {
+        validateReplyContent(request.content());
+
+        User user = userQueryPort.findById(request.userId());
+        Review review = reviewQueryPort.findById(request.reviewId());
+
+        validateReviewOwner(user, review);
+        reviewCommandPort.saveReviewReply(review.addReviewReply(request.content().trim()));
+    }
+
+    @Transactional
+    @Override
+    public void deleteReviewReply(final DeleteReviewReplyServiceRequest request) {
+        User user = userQueryPort.findById(request.userId());
+        Review review = reviewQueryPort.findById(request.reviewId());
+
+        validateReviewOwner(user, review);
+        review.deleteReviewReply();
+    }
+
+    @Transactional
+    @Override
     public void reportReview(final ReportReviewServiceRequest request) {
         User user = userQueryPort.findById(request.userId());
         Review review = reviewQueryPort.findById(request.reviewId());
@@ -96,6 +119,18 @@ public class ReviewService implements ReviewUseCase {
     private void existsOrderReview(final OrderGoods orderGoods, final User user) {
         if (reviewQueryPort.existsOrderAndReview(orderGoods, user)) {
             throw new DuplicateException(ErrorCode.DUPLICATE_REVIEW);
+        }
+    }
+
+    private void validateReviewOwner(final User user, final Review review) {
+        if (user.getUserRole() != UserRole.OWNER || !review.getOrderGoods().getGoods().getStore().isOwnedBy(user)) {
+            throw new InvalidRequestException(ErrorCode.INVALID_STORE_OWNER);
+        }
+    }
+
+    private void validateReplyContent(final String content) {
+        if (content == null || content.isBlank() || content.length() > 500) {
+            throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_RATING);
         }
     }
 }

--- a/src/main/java/com/magambell/server/review/app/service/ReviewService.java
+++ b/src/main/java/com/magambell/server/review/app/service/ReviewService.java
@@ -130,7 +130,7 @@ public class ReviewService implements ReviewUseCase {
 
     private void validateReplyContent(final String content) {
         if (content == null || content.isBlank() || content.length() > 500) {
-            throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_RATING);
+            throw new InvalidRequestException(ErrorCode.INVALID_REVIEW_REPLY_CONTENT);
         }
     }
 }

--- a/src/main/java/com/magambell/server/review/domain/entity/Review.java
+++ b/src/main/java/com/magambell/server/review/domain/entity/Review.java
@@ -2,6 +2,7 @@ package com.magambell.server.review.domain.entity;
 
 import com.magambell.server.common.BaseTimeEntity;
 import com.magambell.server.common.enums.ErrorCode;
+import com.magambell.server.common.exception.DuplicateException;
 import com.magambell.server.common.exception.InvalidRequestException;
 import com.magambell.server.order.domain.entity.OrderGoods;
 import com.magambell.server.review.app.port.in.dto.RegisterReviewDTO;
@@ -44,6 +45,8 @@ public class Review extends BaseTimeEntity {
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
     private List<ReviewImage> reviewImages = new ArrayList<>();
 
+    @OneToOne(mappedBy = "review", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private ReviewReply reviewReply;
 
     @Builder(access = AccessLevel.PRIVATE)
     private Review(final Integer rating, final String description, final ReviewStatus reviewStatus) {
@@ -84,7 +87,29 @@ public class Review extends BaseTimeEntity {
         reviewImage.addReview(this);
     }
 
+    public void addReviewReply(final String content) {
+        if (this.reviewReply != null && this.reviewReply.isActive()) {
+            throw new DuplicateException(ErrorCode.DUPLICATE_REVIEW_REPLY);
+        }
+
+        if (this.reviewReply != null) {
+            this.reviewReply.restore(content);
+            return;
+        }
+
+        ReviewReply reply = ReviewReply.create(content);
+        this.reviewReply = reply;
+        reply.addReview(this);
+    }
+
+    public void deleteReviewReply() {
+        if (this.reviewReply != null) {
+            this.reviewReply.delete();
+        }
+    }
+
     public void delete() {
         this.reviewStatus = ReviewStatus.DELETED;
+        deleteReviewReply();
     }
 }

--- a/src/main/java/com/magambell/server/review/domain/entity/Review.java
+++ b/src/main/java/com/magambell/server/review/domain/entity/Review.java
@@ -87,19 +87,20 @@ public class Review extends BaseTimeEntity {
         reviewImage.addReview(this);
     }
 
-    public void addReviewReply(final String content) {
+    public ReviewReply addReviewReply(final String content) {
         if (this.reviewReply != null && this.reviewReply.isActive()) {
             throw new DuplicateException(ErrorCode.DUPLICATE_REVIEW_REPLY);
         }
 
         if (this.reviewReply != null) {
             this.reviewReply.restore(content);
-            return;
+            return this.reviewReply;
         }
 
         ReviewReply reply = ReviewReply.create(content);
         this.reviewReply = reply;
         reply.addReview(this);
+        return reply;
     }
 
     public void deleteReviewReply() {

--- a/src/main/java/com/magambell/server/review/domain/entity/ReviewReply.java
+++ b/src/main/java/com/magambell/server/review/domain/entity/ReviewReply.java
@@ -1,0 +1,77 @@
+package com.magambell.server.review.domain.entity;
+
+import com.magambell.server.common.BaseTimeEntity;
+import com.magambell.server.review.domain.enums.ReviewReplyStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_review_reply_review_id", columnNames = "review_id")
+        }
+)
+@Entity
+public class ReviewReply extends BaseTimeEntity {
+
+    @Column(name = "review_reply_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReviewReplyStatus replyStatus;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ReviewReply(final String content, final ReviewReplyStatus replyStatus) {
+        this.content = content;
+        this.replyStatus = replyStatus;
+    }
+
+    public static ReviewReply create(final String content) {
+        return ReviewReply.builder()
+                .content(content)
+                .replyStatus(ReviewReplyStatus.ACTIVE)
+                .build();
+    }
+
+    public boolean isActive() {
+        return this.replyStatus == ReviewReplyStatus.ACTIVE;
+    }
+
+    public void addReview(final Review review) {
+        this.review = review;
+    }
+
+    public void restore(final String content) {
+        this.content = content;
+        this.replyStatus = ReviewReplyStatus.ACTIVE;
+    }
+
+    public void delete() {
+        this.replyStatus = ReviewReplyStatus.DELETED;
+    }
+}

--- a/src/main/java/com/magambell/server/review/domain/enums/ReviewReplyStatus.java
+++ b/src/main/java/com/magambell/server/review/domain/enums/ReviewReplyStatus.java
@@ -1,0 +1,11 @@
+package com.magambell.server.review.domain.enums;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ReviewReplyStatus {
+    ACTIVE("등록"),
+    DELETED("삭제");
+
+    private final String text;
+}

--- a/src/main/java/com/magambell/server/review/domain/repository/ReviewReplyRepository.java
+++ b/src/main/java/com/magambell/server/review/domain/repository/ReviewReplyRepository.java
@@ -1,0 +1,7 @@
+package com.magambell.server.review.domain.repository;
+
+import com.magambell.server.review.domain.entity.ReviewReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewReplyRepository extends JpaRepository<ReviewReply, Long> {
+}

--- a/src/test/java/com/magambell/server/review/app/service/ReviewServiceTest.java
+++ b/src/test/java/com/magambell/server/review/app/service/ReviewServiceTest.java
@@ -25,6 +25,7 @@ import com.magambell.server.review.app.port.in.request.RegisterReviewServiceRequ
 import com.magambell.server.review.app.port.in.request.ReviewListServiceRequest;
 import com.magambell.server.review.app.port.in.request.ReviewMyServiceRequest;
 import com.magambell.server.review.app.port.in.request.ReviewRatingAllServiceRequest;
+import com.magambell.server.review.app.port.out.ReviewCommandPort;
 import com.magambell.server.review.app.port.out.response.ReviewListDTO;
 import com.magambell.server.review.app.port.out.response.ReviewRatingSummaryDTO;
 import com.magambell.server.review.domain.entity.ReviewReply;
@@ -84,6 +85,8 @@ class ReviewServiceTest {
     private ReviewImageRepository reviewImageRepository;
     @Autowired
     private ReviewService reviewService;
+    @Autowired
+    private ReviewCommandPort reviewCommandPort;
     @Autowired
     private OrderRepository orderRepository;
     @Autowired
@@ -350,6 +353,23 @@ class ReviewServiceTest {
                 owner.getId(),
                 "두 번째 답글"
         ))).isInstanceOf(DuplicateException.class);
+    }
+
+    @DisplayName("리뷰 답글 review_id unique 제약 위반은 중복 답글 예외로 변환된다.")
+    @Test
+    void saveReviewReply_translatesReviewIdUniqueConstraintViolation() {
+        // given
+        Review review = saveReview();
+        ReviewReply firstReply = ReviewReply.create("첫 번째 답글");
+        firstReply.addReview(review);
+        reviewReplyRepository.saveAndFlush(firstReply);
+
+        ReviewReply duplicateReply = ReviewReply.create("두 번째 답글");
+        duplicateReply.addReview(review);
+
+        // when & then
+        assertThatThrownBy(() -> reviewCommandPort.saveReviewReply(duplicateReply))
+                .isInstanceOf(DuplicateException.class);
     }
 
     @DisplayName("답글 내용이 blank이면 작성에 실패한다.")

--- a/src/test/java/com/magambell/server/review/app/service/ReviewServiceTest.java
+++ b/src/test/java/com/magambell/server/review/app/service/ReviewServiceTest.java
@@ -2,8 +2,11 @@ package com.magambell.server.review.app.service;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.magambell.server.auth.domain.ProviderType;
+import com.magambell.server.common.exception.DuplicateException;
+import com.magambell.server.common.exception.InvalidRequestException;
 import com.magambell.server.goods.adapter.in.web.GoodsImagesRegister;
 import com.magambell.server.goods.app.port.in.dto.RegisterGoodsDTO;
 import com.magambell.server.goods.domain.entity.Goods;
@@ -15,16 +18,21 @@ import com.magambell.server.order.domain.repository.OrderGoodsRepository;
 import com.magambell.server.order.domain.repository.OrderRepository;
 import com.magambell.server.payment.domain.repository.PaymentRepository;
 import com.magambell.server.review.app.port.in.dto.RegisterReviewDTO;
+import com.magambell.server.review.app.port.in.request.DeleteReviewReplyServiceRequest;
 import com.magambell.server.review.app.port.in.request.DeleteReviewServiceRequest;
+import com.magambell.server.review.app.port.in.request.RegisterReviewReplyServiceRequest;
 import com.magambell.server.review.app.port.in.request.RegisterReviewServiceRequest;
 import com.magambell.server.review.app.port.in.request.ReviewListServiceRequest;
 import com.magambell.server.review.app.port.in.request.ReviewMyServiceRequest;
 import com.magambell.server.review.app.port.in.request.ReviewRatingAllServiceRequest;
 import com.magambell.server.review.app.port.out.response.ReviewListDTO;
 import com.magambell.server.review.app.port.out.response.ReviewRatingSummaryDTO;
+import com.magambell.server.review.domain.entity.ReviewReply;
+import com.magambell.server.review.domain.enums.ReviewReplyStatus;
 import com.magambell.server.review.domain.enums.ReviewStatus;
 import com.magambell.server.review.domain.entity.Review;
 import com.magambell.server.review.domain.repository.ReviewImageRepository;
+import com.magambell.server.review.domain.repository.ReviewReplyRepository;
 import com.magambell.server.review.domain.repository.ReviewRepository;
 import com.magambell.server.stock.domain.repository.StockHistoryRepository;
 import com.magambell.server.stock.domain.repository.StockRepository;
@@ -71,6 +79,8 @@ class ReviewServiceTest {
     @Autowired
     private ReviewRepository reviewRepository;
     @Autowired
+    private ReviewReplyRepository reviewReplyRepository;
+    @Autowired
     private ReviewImageRepository reviewImageRepository;
     @Autowired
     private ReviewService reviewService;
@@ -81,6 +91,7 @@ class ReviewServiceTest {
     @Autowired
     private PaymentRepository paymentRepository;
     private User user;
+    private User owner;
     private Goods goods;
     private Order order;
     private OrderGoods orderGoods;
@@ -103,7 +114,7 @@ class ReviewServiceTest {
                 "123974",
                 UserRole.OWNER
         );
-        User owner = ownerAccountDTO.toUser();
+        owner = ownerAccountDTO.toUser();
         owner.addUserSocialAccount(ownerAccountDTO.toUserSocialAccount());
 
         // 매장 생성
@@ -147,6 +158,7 @@ class ReviewServiceTest {
     @AfterEach
     void tearDown() {
         reviewImageRepository.deleteAllInBatch();
+        reviewReplyRepository.deleteAllInBatch();
         reviewRepository.deleteAllInBatch();
         stockHistoryRepository.deleteAllInBatch();
         stockRepository.deleteAllInBatch();
@@ -300,6 +312,128 @@ class ReviewServiceTest {
         assertThat(reviewAll.get(0).getReviewStatus()).isEqualTo(ReviewStatus.DELETED);
     }
 
+    @DisplayName("사장님이 본인 매장 리뷰에 답글을 작성한다.")
+    @Test
+    void registerReviewReply() {
+        // given
+        Review review = saveReview();
+        RegisterReviewReplyServiceRequest request = new RegisterReviewReplyServiceRequest(
+                review.getId(),
+                owner.getId(),
+                "방문해 주셔서 감사합니다."
+        );
+
+        // when
+        reviewService.registerReviewReply(request);
+
+        // then
+        ReviewReply reply = reviewReplyRepository.findAll().get(0);
+        assertThat(reply.getReview().getId()).isEqualTo(review.getId());
+        assertThat(reply.getContent()).isEqualTo("방문해 주셔서 감사합니다.");
+        assertThat(reply.getReplyStatus()).isEqualTo(ReviewReplyStatus.ACTIVE);
+    }
+
+    @DisplayName("이미 ACTIVE 답글이 있으면 중복 답글 작성에 실패한다.")
+    @Test
+    void registerReviewReply_throwsWhenDuplicateActiveReply() {
+        // given
+        Review review = saveReview();
+        reviewService.registerReviewReply(new RegisterReviewReplyServiceRequest(
+                review.getId(),
+                owner.getId(),
+                "첫 번째 답글"
+        ));
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.registerReviewReply(new RegisterReviewReplyServiceRequest(
+                review.getId(),
+                owner.getId(),
+                "두 번째 답글"
+        ))).isInstanceOf(DuplicateException.class);
+    }
+
+    @DisplayName("답글 내용이 blank이면 작성에 실패한다.")
+    @Test
+    void registerReviewReply_throwsWhenContentBlank() {
+        // given
+        Review review = saveReview();
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.registerReviewReply(new RegisterReviewReplyServiceRequest(
+                review.getId(),
+                owner.getId(),
+                "   "
+        ))).isInstanceOf(InvalidRequestException.class);
+    }
+
+    @DisplayName("답글 내용이 500자를 초과하면 작성에 실패한다.")
+    @Test
+    void registerReviewReply_throwsWhenContentTooLong() {
+        // given
+        Review review = saveReview();
+        String content = "a".repeat(501);
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.registerReviewReply(new RegisterReviewReplyServiceRequest(
+                review.getId(),
+                owner.getId(),
+                content
+        ))).isInstanceOf(InvalidRequestException.class);
+    }
+
+    @DisplayName("타 매장 사장님은 답글 작성에 실패한다.")
+    @Test
+    void registerReviewReply_throwsWhenNotStoreOwner() {
+        // given
+        Review review = saveReview();
+        User otherOwner = saveOwner("other-owner@test.com", "other-owner-social-id");
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.registerReviewReply(new RegisterReviewReplyServiceRequest(
+                review.getId(),
+                otherOwner.getId(),
+                "타 매장 답글"
+        ))).isInstanceOf(InvalidRequestException.class);
+    }
+
+    @DisplayName("사장님이 본인 매장 리뷰 답글을 삭제한다.")
+    @Test
+    void deleteReviewReply() {
+        // given
+        Review review = saveReview();
+        reviewService.registerReviewReply(new RegisterReviewReplyServiceRequest(
+                review.getId(),
+                owner.getId(),
+                "삭제할 답글"
+        ));
+
+        // when
+        reviewService.deleteReviewReply(new DeleteReviewReplyServiceRequest(review.getId(), owner.getId()));
+
+        // then
+        ReviewReply reply = reviewReplyRepository.findAll().get(0);
+        assertThat(reply.getReplyStatus()).isEqualTo(ReviewReplyStatus.DELETED);
+    }
+
+    @DisplayName("리뷰를 삭제하면 연결된 답글도 DELETED 상태로 변경된다.")
+    @Test
+    void deleteReview_deletesReviewReply() {
+        // given
+        Review review = saveReview();
+        reviewService.registerReviewReply(new RegisterReviewReplyServiceRequest(
+                review.getId(),
+                owner.getId(),
+                "리뷰 삭제 시 함께 삭제될 답글"
+        ));
+
+        // when
+        reviewService.deleteReview(new DeleteReviewServiceRequest(review.getId(), user.getId()));
+
+        // then
+        ReviewReply reply = reviewReplyRepository.findAll().get(0);
+        assertThat(reply.getReplyStatus()).isEqualTo(ReviewReplyStatus.DELETED);
+    }
+
     private Review createReview(int i) {
         CreateOrderDTO createOrderDTO = new CreateOrderDTO(user, goods, 1, 9000, LocalDateTime.now(), "test");
         Order createOrder = createOrderDTO.toOrder();
@@ -317,5 +451,32 @@ class ReviewServiceTest {
         );
 
         return Review.create(dto);
+    }
+
+    private Review saveReview() {
+        RegisterReviewDTO dto = new RegisterReviewDTO(
+                orderGoods.getId(),
+                2,
+                "test",
+                List.of(),
+                user,
+                orderGoods
+        );
+        return reviewRepository.save(Review.create(dto));
+    }
+
+    private User saveOwner(final String email, final String socialId) {
+        UserSocialAccountDTO ownerAccountDTO = new UserSocialAccountDTO(
+                email,
+                "다른 사장님",
+                "다른 사장님 닉네임",
+                "01088889999",
+                ProviderType.KAKAO,
+                socialId,
+                UserRole.OWNER
+        );
+        User otherOwner = ownerAccountDTO.toUser();
+        otherOwner.addUserSocialAccount(ownerAccountDTO.toUserSocialAccount());
+        return userRepository.save(otherOwner);
     }
 }

--- a/src/test/java/com/magambell/server/review/app/service/ReviewServiceTest.java
+++ b/src/test/java/com/magambell/server/review/app/service/ReviewServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.magambell.server.auth.domain.ProviderType;
+import com.magambell.server.common.enums.ErrorCode;
 import com.magambell.server.common.exception.DuplicateException;
 import com.magambell.server.common.exception.InvalidRequestException;
 import com.magambell.server.goods.adapter.in.web.GoodsImagesRegister;
@@ -383,7 +384,9 @@ class ReviewServiceTest {
                 review.getId(),
                 owner.getId(),
                 "   "
-        ))).isInstanceOf(InvalidRequestException.class);
+        )))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessage(ErrorCode.INVALID_REVIEW_REPLY_CONTENT.getMessage());
     }
 
     @DisplayName("답글 내용이 500자를 초과하면 작성에 실패한다.")
@@ -398,7 +401,9 @@ class ReviewServiceTest {
                 review.getId(),
                 owner.getId(),
                 content
-        ))).isInstanceOf(InvalidRequestException.class);
+        )))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessage(ErrorCode.INVALID_REVIEW_REPLY_CONTENT.getMessage());
     }
 
     @DisplayName("타 매장 사장님은 답글 작성에 실패한다.")


### PR DESCRIPTION
## 🔗 Related Issue
<!-- 연관된 이슈를 태그해 주세요. -->
- close #211 

## 🪄 Work Description
<!-- 작업한 내용을 간략히 설명해 주세요. -->
리뷰 답글 도메인과 작성/삭제 API를 추가했습니다.  
리뷰 1개당 답글 1개만 가질 수 있도록 `ReviewReply` 엔티티를 도입했고, 
답글은 하드 삭제가 아닌 `DELETED` 상태로 소프트 삭제되도록 구현했습니다.  
리뷰 삭제 시 연결된 답글도 함께 삭제 상태로 전파됩니다.

## 💥 Changes
<!-- 변경된 사항을 체크리스트로 작성해 주세요. -->
- [x] `ReviewReply` 엔티티 추가                   
- [x] `ReviewReplyStatus` enum 추가 (`ACTIVE`, `DELETED`)                                        
- [x] `Review`와 `ReviewReply` 1:1 관계 매핑      
- [x] `review_id` unique 제약 선언                
- [x] 답글 작성/삭제 도메인 메서드 추가           
- [x] 리뷰 삭제 시 답글 소프트 삭제 전파 추가     
- [x] `ReviewReplyRepository` 추가                
- [x] 답글 작성 요청 DTO 및 서비스 요청 객체 추가 
- [x] `POST /api/v1/review/{reviewId}/reply` API 추가                                              
- [x] `DELETE /api/v1/review/{reviewId}/reply` API 추가                                              
- [x] OWNER 및 매장 소유자 검증 추가              
- [x] content blank 및 500자 초과 검증 추가       
- [x] ACTIVE 답글 중복 작성 시 `DUPLICATE_REVIEW_REPLY` 처리                     
- [x] 답글 작성/삭제 서비스 테스트 추가           
- [x] 리뷰 삭제 시 답글도 `DELETED` 처리되는 테스트 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Store owners can add replies to reviews.
  * Store owners can delete existing review replies.
  * Deleted replies can be restored when a new reply is added.
* **Bug Fixes**
  * Reply content is validated from 1 to 500 characters.
  * Duplicate active replies are rejected.
  * Unauthorized users cannot manage review replies.
  * Replies are removed when their associated review is deleted.
* **Tests**
  * Added coverage for reply creation, deletion, restoration, validation, authorization, and cascading removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->